### PR TITLE
Add depmod to setup script

### DIFF
--- a/docker-install.sh
+++ b/docker-install.sh
@@ -222,6 +222,8 @@ then
               sudo -E "$(which bash)" -c "modprobe -r $module 2>/dev/null" || true
             fi
         done
+        # Rebuild module dependency database factoring in blacklists
+        which depmod >/dev/null 2>&1 && depmod -a || true
         # On systems with initramfs, this needs to be updated to make sure the exclusions take effect:
         which update-initramfs >/dev/null 2>&1 && sudo update-initramfs -u || true 
     popd >/dev/null


### PR DESCRIPTION
- add depmod to setup script in order to properly rebuild the module dependency database while factoring in the blacklist changes we have made, and in a specific order, before the update-initramfs operation occurs.

From the [depmod manual page](https://linux.die.net/man/8/depmod):

"Linux kernel modules can provide services (called symbols) for other modules to use (using EXPORT_SYMBOL in the code). If a second module uses this symbol, that second module clearly depends on the first module. These dependencies can get quite complex.

depmod creates a list of module dependencies by reading each module under /lib/modules/version and determining what symbols it exports and what symbols it needs. By default, this list is written to modules.dep in the same directory. depmod will also generate various map files in this directory for use by the hotplug infrastructure."