### PR TITLE
make docker compose wait longer before killing containers

### DIFF
--- a/docker-install.sh
+++ b/docker-install.sh
@@ -94,6 +94,8 @@ else
     "max-size": "10m",
     "max-file": "3"
   }
+  "shutdown-timeout": 300,
+  "live-restore": true
 }
 EOF
     sudo chmod u=rw,go=r /etc/docker/daemon.json


### PR DESCRIPTION
Especially on a Pi or similar system running several containers, the default 10 seconds aren't enough and that way cleanup tasks aren't being run reliably at container exit (e.g. the copying of the range outline to persistant storage).