### PR TITLE
Remove READSB_MODEAC=true from suggested/example ultrafeeder config

### DIFF
--- a/sample-docker-compose.yml
+++ b/sample-docker-compose.yml
@@ -60,7 +60,6 @@ services:
       - READSB_LON=${FEEDER_LONG}
       - READSB_ALT=${FEEDER_ALT_M}m
       - READSB_GAIN=${ADSB_SDR_GAIN}
-      - READSB_MODEAC=true
       - READSB_RX_LOCATION_ACCURACY=2
       - READSB_STATS_RANGE=true
       #


### PR DESCRIPTION
Remove READSB_MODEAC=true from suggested/example ultrafeeder config

None of the feeder sites process Mode A/C messages, it just wastes CPU cycles to decode these.